### PR TITLE
⚡️ Remove un-necessary TAF delay

### DIFF
--- a/src/pywwa/workflows/taf.py
+++ b/src/pywwa/workflows/taf.py
@@ -1,18 +1,11 @@
 """TAF Ingestor"""
 
-from typing import TYPE_CHECKING
-
 import click
 from pyiem.nws.products.taf import parser
-from twisted.internet import reactor
-from twisted.internet.interfaces import IReactorTime
 
 from pywwa import common
 from pywwa.database import get_database
 from pywwa.ldm import bridge
-
-if TYPE_CHECKING:
-    reactor: IReactorTime
 
 
 def real_process(txn, raw):
@@ -22,11 +15,8 @@ def real_process(txn, raw):
         prod.sql(txn)
     baseurl = common.SETTINGS.get("pywwa_product_url", "pywwa_product_url")
     jmsgs = prod.get_jabbers(baseurl)
-    # The downstream workflow needs to have these TAF messages available within
-    # the AFOS database, so we add some delay here.
-    # 15 seconds wasn't enough?
     for mess, htmlmess, xtra in jmsgs:
-        reactor.callLater(30, common.send_message, mess, htmlmess, xtra)
+        common.send_message(mess, htmlmess, xtra)
     if prod.warnings:
         common.email_error("\n\n".join(prod.warnings), prod.text)
 


### PR DESCRIPTION
The latency with afos_dump was fixed, so we should not need to wait around anymore.