### PR TITLE
Handle unknown nexrad id as a long message, add DJT entries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 'v2.25.1'
+    rev: 'v2.25.2'
     hooks:
       - id: pyproject-fmt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this library are documented in this file.
 ### API Changes
 
 - Bump minimum python to 3.11
+- Demote unknown station in nexrad3 attribute processing to a log message.
 
 ### New Features
 

--- a/src/pywwa/data/faa_apt.tbl
+++ b/src/pywwa/data/faa_apt.tbl
@@ -4004,6 +4004,7 @@ FD13     ------ CLEVELAND CLINIC FLORIDA HOSPITA FL --  2608  -8036    -- --
 FD38     ------ WELLINGTON AERO CLUB             FL --  2664  -8029    -- --
 F45      ------ NORTH PALM BEACH COUNTY GENERAL  FL --  2684  -8022    -- --
 PBI      ------ PALM BEACH INTL                  FL --  2668  -8009    -- --
+DJT      ------ PALM BEACH INTL                  FL --  2668  -8009    -- --
 LNA      ------ PALM BEACH COUNTY PARK           FL --  2659  -8008    -- --
 64FD     ------ ST MARYS HOSPITAL                FL --  2675  -8006    -- --
 FL39     ------ WELLINGTON MEDICAL CENTER        FL --  2663  -8020    -- --

--- a/src/pywwa/data/nexrad.stns
+++ b/src/pywwa/data/nexrad.stns
@@ -198,5 +198,6 @@ TUL      000000 Tulsa, OK                        OK US  3607  -9582    00  0 TWD
 ADW      000000 Washington D.C. (Andrews AFB,MD  DC US  3869  -7684    00  0 TWDR
 DCA      000000 Washington, D.C. (National)      DC US  3875  -7696    00  0 TWDR
 PBI      000000 West Palm Beach, FL              FL US  2668  -8027    00  0 TWDR
+DJT      000000 West Palm Beach, FL              FL US  2668  -8027    00  0 TWDR
 ICH      000000 Wichita, KS                      KS US  3750  -9743    00  0 TWDR
 VWX      000851 EVANSVILLE/Owensville            IN US  3827  -8772   190  0 NWS

--- a/src/pywwa/data/pirep_navaids.tbl
+++ b/src/pywwa/data/pirep_navaids.tbl
@@ -4053,6 +4053,7 @@ PBF           0 PINE_BLUFF                       -- --  3425  -9193     0  0
 PBG           0 PLATTSBURG                       NY US  4468  -7352     0  0                    
 PBH           0 PHILLIPS                         -- --  4570  -9041     0  0                    
 PBI           0 PALM_BEACH                       -- --  2668  -8009     0  0                    
+DJT           0 PALM_BEACH                       -- --  2668  -8009     0  0                    
 PBR           0 PEMBROKE                         NH US  4312  -7145     0  0                    
 PBT           0 PROBERTA                         -- --  4011 -12224     0  0                    
 PBV           0 GEORGE                           AK US  5658 -16966     0  0                    

--- a/src/pywwa/data/vors.tbl
+++ b/src/pywwa/data/vors.tbl
@@ -67,6 +67,7 @@ FLO      000102 FLORENCE                         SC US  3423  -7966     0  0
 GSO      000122 GREENSBORO                       NC US  3605  -7998     0  0
 CHS      000056 CHARLESTON                       SC US  3289  -8004     0  0
 PBI      000206 WEST_PALM_BEACH                  FL US  2668  -8009     0  0
+DJT      000206 WEST_PALM_BEACH                  FL US  2668  -8009     0  0
 EKN      000088 ELKINS                           WV US  3892  -8010     0  0
 EWC      000326 ELLWOOD_CITY                     PA US  4083  -8021     0  0
 ERI      000092 ERIE                             PA US  4202  -8030     0  0

--- a/src/pywwa/workflows/nexrad3_attr.py
+++ b/src/pywwa/workflows/nexrad3_attr.py
@@ -91,10 +91,10 @@ def really_process(txn, ctx):
          U8  154/126 NONE NONE     UNKNOWN       11  47 18.8  23.1  271/ 70
          J0  127/134 NONE NONE     UNKNOWN       24  51 20.2  33.9    NEW
     """
-    delete_prev_attrs(txn, ctx["nexrad"])
     if ctx["nexrad"] not in ST:
         LOG.warning("Unknown station %s", ctx["nexrad"])
         return 0
+    delete_prev_attrs(txn, ctx["nexrad"])
     cenlat = float(ST[ctx["nexrad"]]["lat"])
     cenlon = float(ST[ctx["nexrad"]]["lon"])
     latscale = 111137.0

--- a/src/pywwa/workflows/nexrad3_attr.py
+++ b/src/pywwa/workflows/nexrad3_attr.py
@@ -92,7 +92,9 @@ def really_process(txn, ctx):
          J0  127/134 NONE NONE     UNKNOWN       24  51 20.2  33.9    NEW
     """
     delete_prev_attrs(txn, ctx["nexrad"])
-
+    if ctx["nexrad"] not in ST:
+        LOG.warning("Unknown station %s", ctx["nexrad"])
+        return 0
     cenlat = float(ST[ctx["nexrad"]]["lat"])
     cenlon = float(ST[ctx["nexrad"]]["lon"])
     latscale = 111137.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unknown station data so processing now logs a warning instead of failing.
  * Added support for the `DJT` identifier across airport, radar, navaid, and VOR reference data.

* **Chores**
  * Updated a pre-commit formatting hook to the latest patch version.

* **Documentation**
  * Noted the station-handling change in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->