### PR TITLE
Update ruff and add fake AFOS entries for two earthquake products

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.21"
+    rev: "v0.15.22"
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this library are documented in this file.
 
 ### New Features
 
+- Add fake AFOS entries for ADMN75 and SEXX01 Earthquake products.
 - [SHEF] persist narrative/comments to `current_shef` IEMAccess storage.
 
 ### Bug Fixes

--- a/pqact.d/pqact_afos.conf
+++ b/pqact.d/pqact_afos.conf
@@ -32,6 +32,12 @@ IDS|DDPLUS|HDS	^F.* /p((MAV|MEX|MET|ECS|ECX|ECM|LAV|LEV)...)
 NGRID	^F(E|O)US1([5-8]) KWNO ....00 /pNB(E|H|P|S|X)
 	PIPE	pywwa-parse-split-mav
 
+# P-Type Message (Earthquake)
+WMO	^SEXX01 PHEB
+	PIPE	pywwa-parse-fake-afos-dump
+# Observatory Message (Earthquake)
+WMO	^ADMN75 PAAQ
+	PIPE	pywwa-parse-fake-afos-dump
 IDS|DDPLUS	^CDUS27
 	PIPE	pywwa-parse-fake-afos-dump
 IDS|DDPLUS	^NOXX.. .(...)

--- a/src/pywwa/workflows/fake_afos_dump.py
+++ b/src/pywwa/workflows/fake_afos_dump.py
@@ -44,6 +44,7 @@ NHC = {
     "URPN14": "REPPNS",
     "UZGL01": "UZGL01",  # email to NHC about this
 }
+ONE_TO_ONE = ["ADMN75", "SEXX01"]
 
 
 def compute_afos(textprod: TextProduct):
@@ -57,6 +58,8 @@ def compute_afos(textprod: TextProduct):
         afos = "PIREP"
     elif ttaaii in GMET:
         afos = GMET[ttaaii]
+    elif ttaaii in ONE_TO_ONE:
+        afos = ttaaii
     elif MIS.match(ttaaii):
         afos = f"MIS{textprod.source[1:]}"
     elif CWA.match(ttaaii):


### PR DESCRIPTION
https://tgftp.nws.noaa.gov/data/raw/ad/admn75.paaq..txt
https://tgftp.nws.noaa.gov/data/raw/se/sexx01.pheb..txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing fake AFOS earthquake entries for products ADMN75 and SEXX01.
  * These entries are now routed and assigned matching AFOS identifiers for downstream processing.

* **Documentation**
  * Updated the changelog to document support for the two additional earthquake products.

* **Chores**
  * Updated the Ruff pre-commit tooling version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->