### PR TITLE
Bump ruff and fix double encode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.4"
+    rev: "v0.16.5"
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/src/pywwa/xmpp.py
+++ b/src/pywwa/xmpp.py
@@ -1,11 +1,10 @@
 """XMPP/Jabber Client Interface and Support."""
 
-# stdlib
 import inspect
 import os
 import re
+from html import escape, unescape
 
-# Third Party
 import pyiem
 import treq
 from pyiem.util import utc
@@ -17,7 +16,6 @@ from twisted.words.protocols.jabber import xmlstream
 from twisted.words.protocols.jabber.jid import JID
 from twisted.words.xish import domish, xpath
 
-# Local
 from pywwa import CTX, LOG, SETTINGS, shutdown
 
 # http://stackoverflow.com/questions/7016602
@@ -218,7 +216,7 @@ class JabberClient:
         self.authenticated = False
 
     @inlineCallbacks
-    def send_message(self, body, html, xtra):
+    def send_message(self, body: str, html: str, xtra: dict):
         """
         Send a message to nwsbot.  This message should have
         @param body plain text variant
@@ -232,17 +230,19 @@ class JabberClient:
                 self.send_message,
                 body,
                 html,
-                xtra,  # @UndefinedVariable
+                xtra,
             )
             return
         message = domish.Element(("jabber:client", "message"))
         message["to"] = self.routerjid
         message["type"] = "chat"
 
-        body = ILLEGAL_XML_CHARS_RE.sub("", body)
+        body = escape(unescape(ILLEGAL_XML_CHARS_RE.sub("", body)))
         if html:
             html = ILLEGAL_XML_CHARS_RE.sub("", html)
-        message.addElement("body", None, body)
+        # body may already be HTML entities encoded, so we need to be careful
+        # here not to re-encode them
+        message.addElement("body").addRawXml(body)
         helem = message.addElement(
             "html", "http://jabber.org/protocol/xhtml-im"
         )

--- a/tests/test_xmpp.py
+++ b/tests/test_xmpp.py
@@ -3,8 +3,10 @@
 from unittest import mock
 
 import pytest
+import pytest_twisted
 from twisted.words.protocols.jabber import jid
 from twisted.words.xish import domish, xmlstream
+from twisted.words.xish.domish import Element
 
 from pywwa import CTX, xmpp
 
@@ -12,7 +14,16 @@ from pywwa import CTX, xmpp
 @pytest.fixture(autouse=True)
 def reactor():
     """Fixture"""
-    return mock.Mock()
+    my = mock.Mock()
+
+    def callme(func, *args, **kwargs):
+        """Call the function if it is callable."""
+        print("callme", args)
+        return func(*args, **kwargs)
+
+    my.callFromThread = callme
+
+    return my
 
 
 def test_raw_data_in():
@@ -64,21 +75,39 @@ def test_illegal_xml():
     assert xmpp.ILLEGAL_XML_CHARS_RE.sub("", "\003hello") == "hello"
 
 
-def test_send_message(reactor):
-    """Test the sending of messages."""
-    client = xmpp.JabberClient(reactor, jid.JID("root@localhost"), "secret")
+@pytest_twisted.inlineCallbacks
+def test_gh341_double_encode(reactor):
+    """Test that messages already with html entities do not get doubled."""
+    client = xmpp.JabberClient(reactor, jid.JID("root@l"), "s")
     client.authenticated = True
-    client.xmlstream = xmlstream.XmlStream()
-    client.send_message(
-        "hello",
-        "hello",
+    client.xmlstream = mock.Mock()
+
+    captured = []
+
+    def localsend(message: Element):
+        """Local send method to capture the output."""
+        print("localsend", type(message))
+        captured.append(message)
+        print("wrote captured")
+
+    client.xmlstream.send = localsend
+    _ = yield client.send_message(
+        "This is already &gt; OK &",
+        "<strong>Likewise &lt;gt;</strong> This is already &amp; OK",
         {
             "channels": ["XX", "YY"],
-            "t": "x",
-            "twitter_media": "http://thiswillfail.lazz/bogus",
         },
     )
-    client.disconnect(None)
+    sent_message = captured[0]
+    ans = (
+        "<message xmlns='jabber:client' to='iembot@localhost' type='chat'>"
+        "<body>This is already &gt; OK &amp;</body>"
+        "<html xmlns='http://jabber.org/protocol/xhtml-im'>"
+        "<body xmlns='http://www.w3.org/1999/xhtml'>"
+        "<strong>Likewise &lt;gt;</strong> This is already &amp; OK</body>"
+        "</html><x xmlns='nwschat:nwsbot' channels='XX,YY'/></message>"
+    )
+    assert sent_message.toXml() == ans
 
 
 def test_client(reactor):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XMPP message handling by preventing double-encoding of pre-escaped entities.
  * Sanitized message content to preserve valid HTML and channel metadata while removing invalid XML characters.

* **Tests**
  * Added regression coverage for message encoding and asynchronous XMPP behavior.

* **Chores**
  * Updated the Ruff pre-commit tooling revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->